### PR TITLE
feat: 브릭 리스트 추가, 브릭 리스트에 맞게 ui 동적 연결

### DIFF
--- a/config/brick-config.ts
+++ b/config/brick-config.ts
@@ -1,0 +1,34 @@
+export const LDRAW_PATH = "/ldraw/";
+
+export type CatalogItem = {
+  id: string;
+  name: string;
+  kind: "brick" | "plate";
+  path: string;
+};
+
+export const BRICK_CATALOG: CatalogItem[] = [
+  { id: "3005", name: "1x1 Brick", kind: "brick", path: "/ldraw/parts/3005.dat" },
+  { id: "3004", name: "1x2 Brick", kind: "brick", path: "/ldraw/parts/3004.dat" },
+  { id: "3003", name: "2x2 Brick", kind: "brick", path: "/ldraw/parts/3003.dat" },
+  { id: "3002", name: "2x3 Brick", kind: "brick", path: "/ldraw/parts/3002.dat" },
+  { id: "3001", name: "2x4 Brick", kind: "brick", path: "/ldraw/parts/3001.dat" },
+  { id: "2456", name: "2x6 Brick", kind: "brick", path: "/ldraw/parts/2456.dat" },
+
+  { id: "3024", name: "1x1 Plate", kind: "plate", path: "/ldraw/parts/3024.dat" },
+  { id: "3023", name: "1x2 Plate", kind: "plate", path: "/ldraw/parts/3023.dat" },
+  { id: "3022", name: "2x2 Plate", kind: "plate", path: "/ldraw/parts/3022.dat" },
+  { id: "3021", name: "2x3 Plate", kind: "plate", path: "/ldraw/parts/3021.dat" },
+  { id: "3020", name: "2x4 Plate", kind: "plate", path: "/ldraw/parts/3020.dat" },
+  { id: "3795", name: "2x6 Plate", kind: "plate", path: "/ldraw/parts/3795.dat" },
+];
+
+export const COLOR_PALETTE = [
+  { name: "Turquoise", hex: "#a7f3d0" },
+  { name: "Sky Blue", hex: "#bfdbfe" },
+  { name: "Yellow", hex: "#fde68a" },
+  { name: "Coral", hex: "#fecaca" },
+  { name: "Lavender", hex: "#e9d5ff" },
+] as const;
+
+export type ColorHex = (typeof COLOR_PALETTE)[number]["hex"];

--- a/public/ldraw/p/4-4edge.dat
+++ b/public/ldraw/p/4-4edge.dat
@@ -1,0 +1,20 @@
+0 Circle 1.0
+0 Name: 8\4-4edge.dat
+0 Author: Philippe Hurbain [Philo]
+0 !LDRAW_ORG 8_Primitive UPDATE 2016-01
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2016-12-31 [PTadmin] Official Update 2016-01
+
+
+2 24 1 0 0 0.7071 0 0.7071
+2 24 0.7071 0 0.7071 0 0 1
+2 24 0 0 1 -0.7071 0 0.7071
+2 24 -0.7071 0 0.7071 -1 0 0
+2 24 -1 0 0 -0.7071 0 -0.7071
+2 24 -0.7071 0 -0.7071 0 0 -1
+2 24 0 0 -1 0.7071 0 -0.7071
+2 24 0.7071 0 -0.7071 1 0 0
+0 // Build by Primitive Generator 2

--- a/public/ldraw/p/box4t.dat
+++ b/public/ldraw/p/box4t.dat
@@ -1,0 +1,33 @@
+0 Box with 4 Adjacent Faces and All Edges
+0 Name: box4t.dat
+0 Author: Tore Eriksson [Tore_Eriksson]
+0 !LDRAW_ORG Primitive UPDATE 2003-02
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 1997-09-29 [PTadmin] Official Update 1997-15
+0 !HISTORY 2002-08-31 [izanette] Modified with WINDZ for BFC compliance
+0 !HISTORY 2003-08-01 [PTadmin] Official Update 2003-02
+0 !HISTORY 2007-06-24 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+
+
+2 24 1 1 1 -1 1 1
+2 24 -1 1 1 -1 1 -1
+2 24 -1 1 -1 1 1 -1
+2 24 1 1 -1 1 1 1
+2 24 1 0 1 -1 0 1
+2 24 -1 0 1 -1 0 -1
+2 24 -1 0 -1 1 0 -1
+2 24 1 0 -1 1 0 1
+2 24 1 0 1 1 1 1
+2 24 -1 0 1 -1 1 1
+2 24 1 0 -1 1 1 -1
+2 24 -1 0 -1 -1 1 -1
+4 16 1 1 1 1 1 -1 -1 1 -1 -1 1 1
+4 16 1 1 1 -1 1 1 -1 0 1 1 0 1
+4 16 -1 1 1 -1 1 -1 -1 0 -1 -1 0 1
+0 // 4 16 -1 1 -1 -1 0 -1 1 0 -1 1 1 -1
+4 16 1 1 -1 1 1 1 1 0 1 1 0 -1
+0

--- a/public/ldraw/p/stud3.dat
+++ b/public/ldraw/p/stud3.dat
@@ -1,0 +1,20 @@
+0 Stud Tube Solid
+0 Name: stud3.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Primitive UPDATE 2012-01
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2002-04-04 [sbliss] Modified for BFC compliance
+0 !HISTORY 2002-04-25 [PTadmin] Official Update 2002-02
+0 !HISTORY 2007-06-24 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2012-02-16 [Philo] Changed to CCW
+0 !HISTORY 2012-03-30 [PTadmin] Official Update 2012-01
+
+
+1 16 0 -4 0 4 0 0 0 1 0 0 0 4 4-4edge.dat
+1 16 0 0 0 4 0 0 0 1 0 0 0 4 4-4edge.dat
+1 16 0 -4 0 4 0 0 0 1 0 0 0 4 4-4disc.dat
+1 16 0 -4 0 4 0 0 0 4 0 0 0 4 4-4cyli.dat

--- a/public/ldraw/p/stug-1x2.dat
+++ b/public/ldraw/p/stug-1x2.dat
@@ -1,0 +1,13 @@
+0 Stud Group  1 x  2
+0 Name: stug-1x2.dat
+0 Author: Steffen [Steffen]
+0 !LDRAW_ORG Primitive UPDATE 2011-01
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2011-07-25 [PTadmin] Official Update 2011-01
+
+
+1 16 -10 0 0 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 0 1 0 0 0 1 0 0 0 1 stud.dat

--- a/public/ldraw/p/stug-2x2.dat
+++ b/public/ldraw/p/stug-2x2.dat
@@ -1,0 +1,21 @@
+0 Stud Group  2 x  2
+0 Name: stug-2x2.dat
+0 Author: Steffen [Steffen]
+0 !LDRAW_ORG Primitive UPDATE 2012-01
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2005-12-28 [PTadmin] Official Update 2005-01
+0 !HISTORY 2007-05-04 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2011-07-01 [PTadmin] Renamed from stug2
+0 !HISTORY 2011-07-25 [PTadmin] Official Update 2011-01
+0 !HISTORY 2012-02-16 [Philo] Changed to CCW
+0 !HISTORY 2012-03-30 [PTadmin] Official Update 2012-01
+
+
+1 16 -10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 10 1 0 0 0 1 0 0 0 1 stud.dat

--- a/public/ldraw/parts/2456.dat
+++ b/public/ldraw/parts/2456.dat
@@ -1,0 +1,42 @@
+0 Brick  2 x  6
+0 Name: 2456.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2009-02
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2007-12-20 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2009-04-05 [tchang] Add BFC, file DOS format
+0 !HISTORY 2009-09-03 [PTadmin] Official Update 2009-02
+
+
+1 16 40 4 0 1 0 0 0 -5 0 0 0 1 stud4.dat
+1 16 20 4 0 1 0 0 0 -5 0 0 0 1 stud4.dat
+1 16 0 4 0 1 0 0 0 -5 0 0 0 1 stud4.dat
+1 16 -20 4 0 1 0 0 0 -5 0 0 0 1 stud4.dat
+1 16 -40 4 0 1 0 0 0 -5 0 0 0 1 stud4.dat
+
+0 BFC INVERTNEXT
+1 16 0 24 0 56 0 0 0 -20 0 0 0 16 box5.dat
+
+4 16 60 24 20 56 24 16 -56 24 16 -60 24 20
+4 16 -60 24 20 -56 24 16 -56 24 -16 -60 24 -20
+4 16 -60 24 -20 -56 24 -16 56 24 -16 60 24 -20
+4 16 60 24 -20 56 24 -16 56 24 16 60 24 20
+
+1 16 0 24 0 60 0 0 0 -24 0 0 0 20 box5.dat
+
+1 16 50 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 30 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -30 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -50 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 50 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 30 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -30 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -50 0 -10 1 0 0 0 1 0 0 0 1 stud.dat

--- a/public/ldraw/parts/3002.dat
+++ b/public/ldraw/parts/3002.dat
@@ -1,0 +1,20 @@
+0 Brick  2 x  3
+0 Name: 3002.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2003-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2003-07-03 [Steffen] Subfiled for patterns
+0 !HISTORY 2003-12-19 [PTadmin] Official Update 2003-03
+0 !HISTORY 2007-05-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 s\3002s01.dat
+4 16 -30 0 -20 -30 24 -20 30 24 -20 30 0 -20
+0

--- a/public/ldraw/parts/3003.dat
+++ b/public/ldraw/parts/3003.dat
@@ -1,0 +1,19 @@
+0 Brick  2 x  2
+0 Name: 3003.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2022-05
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2007-05-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2022-08-04 [MagFors] Using subfile
+0 !HISTORY 2022-09-15 [PTadmin] Official Update 2022-05
+
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 s\3003s01.dat
+4 16 -20 24 -20 20 24 -20 20 0 -20 -20 0 -20

--- a/public/ldraw/parts/3004.dat
+++ b/public/ldraw/parts/3004.dat
@@ -1,0 +1,19 @@
+0 Brick  1 x  2
+0 Name: 3004.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2022-05
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2007-05-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2022-08-04 [MagFors] Using subfile
+0 !HISTORY 2022-09-15 [PTadmin] Official Update 2022-05
+
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 s\3004s01.dat
+4 16 -20 24 -10 20 24 -10 20 0 -10 -20 0 -10

--- a/public/ldraw/parts/3005.dat
+++ b/public/ldraw/parts/3005.dat
@@ -1,0 +1,19 @@
+0 Brick  1 x  1
+0 Name: 3005.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2022-05
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2007-05-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2022-08-04 [MagFors] Using subfile
+0 !HISTORY 2022-09-15 [PTadmin] Official Update 2022-05
+
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 s\3005s01.dat
+4 16 -10 24 -10 10 24 -10 10 0 -10 -10 0 -10

--- a/public/ldraw/parts/3020.dat
+++ b/public/ldraw/parts/3020.dat
@@ -1,0 +1,40 @@
+0 Plate  2 x  4
+0 Name: 3020.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2002-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2007-06-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+
+
+1 16 20 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+1 16 0 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+1 16 -20 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+
+0 BFC INVERTNEXT
+1 16 0 8 0 36 0 0 0 -4 0 0 0 16 box5.dat
+
+4 16 40 8 20 36 8 16 -36 8 16 -40 8 20
+0 // Next Line was 4 16 40 8 -20 36 8 -16 -36 8 -16 -40 8 -20
+4 16 -40 8 -20 -36 8 -16 36 8 -16 40 8 -20
+0 // Next Line was 4 16 40 8 20 36 8 16 36 8 -16 40 8 -20
+4 16 40 8 -20 36 8 -16 36 8 16 40 8 20
+4 16 -40 8 20 -36 8 16 -36 8 -16 -40 8 -20
+
+1 16 0 8 0 40 0 0 0 -8 0 0 0 20 box5.dat
+
+1 16 30 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -30 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 30 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -30 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+0

--- a/public/ldraw/parts/3021.dat
+++ b/public/ldraw/parts/3021.dat
@@ -1,0 +1,37 @@
+0 Plate  2 x  3
+0 Name: 3021.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2002-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2007-06-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+
+
+1 16 10 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+1 16 -10 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+
+0 BFC INVERTNEXT
+1 16 0 8 0 26 0 0 0 -4 0 0 0 16 box5.dat
+
+4 16 30 8 20 26 8 16 -26 8 16 -30 8 20
+0 // Next Line was 4 16 30 8 -20 26 8 -16 -26 8 -16 -30 8 -20
+4 16 -30 8 -20 -26 8 -16 26 8 -16 30 8 -20
+0 // Next Line was 4 16 30 8 20 26 8 16 26 8 -16 30 8 -20
+4 16 30 8 -20 26 8 -16 26 8 16 30 8 20
+4 16 -30 8 20 -26 8 16 -26 8 -16 -30 8 -20
+
+1 16 0 8 0 30 0 0 0 -8 0 0 0 20 box5.dat
+
+1 16 20 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 0 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -20 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 20 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 0 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -20 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+0

--- a/public/ldraw/parts/3022.dat
+++ b/public/ldraw/parts/3022.dat
@@ -1,0 +1,34 @@
+0 Plate  2 x  2
+0 Name: 3022.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2002-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2007-06-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+
+
+1 16 0 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+
+0 BFC INVERTNEXT
+1 16 0 8 0 16 0 0 0 -4 0 0 0 16 box5.dat
+
+4 16 20 8 20 16 8 16 -16 8 16 -20 8 20
+0 // Next Line was 4 16 20 8 -20 16 8 -16 -16 8 -16 -20 8 -20
+4 16 -20 8 -20 -16 8 -16 16 8 -16 20 8 -20
+0 // Next Line was 4 16 20 8 20 16 8 16 16 8 -16 20 8 -20
+4 16 20 8 -20 16 8 -16 16 8 16 20 8 20
+4 16 -20 8 20 -16 8 16 -16 8 -16 -20 8 -20
+
+1 16 0 8 0 20 0 0 0 -8 0 0 0 20 box5.dat
+
+1 16 10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+0

--- a/public/ldraw/parts/3023.dat
+++ b/public/ldraw/parts/3023.dat
@@ -1,0 +1,13 @@
+0 ~Moved to 3023b
+0 Name: 3023.dat
+0 Author: Orion Pobursky [OrionP]
+0 !LDRAW_ORG Part UPDATE 2024-07
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2023-06-24 [OrionP] Official Update 2023-03
+0 !HISTORY 2024-08-10 [MagFors] Update description
+0 !HISTORY 2024-08-26 [OrionP] Official Update 2024-07
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 3023b.dat

--- a/public/ldraw/parts/3023b.dat
+++ b/public/ldraw/parts/3023b.dat
@@ -1,0 +1,23 @@
+0 Plate  1 x  2
+0 Name: 3023b.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2023-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !KEYWORDS BrickLink 3023, Rebrickable 3023
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2007-06-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2020-03-07 [Sirio] Subparted
+0 !HISTORY 2022-01-14 [PTadmin] Official Update 2022-01
+0 !HISTORY 2023-05-26 [OrionP] Moved from 3023.dat
+0 !HISTORY 2023-06-24 [OrionP] Official Update 2023-03
+
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 s\3023bs01.dat
+4 16 -20 0 -10 -20 8 -10 20 8 -10 20 0 -10

--- a/public/ldraw/parts/3024.dat
+++ b/public/ldraw/parts/3024.dat
@@ -1,0 +1,19 @@
+0 Plate  1 x  1
+0 Name: 3024.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2022-05
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2001-10-26 [PTadmin] Official Update 2001-01
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2002-06-11 [PTadmin] Official Update 2002-03
+0 !HISTORY 2007-06-07 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2022-08-04 [MagFors] Using subfile
+0 !HISTORY 2022-09-15 [PTadmin] Official Update 2022-05
+
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 s\3024s01.dat
+4 16 -10 8 -10 10 8 -10 10 0 -10 -10 0 -10

--- a/public/ldraw/parts/3795.dat
+++ b/public/ldraw/parts/3795.dat
@@ -1,0 +1,39 @@
+0 Plate  2 x  6
+0 Name: 3795.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Part UPDATE 2003-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CW
+
+0 !HISTORY 2003-08-01 [Steffen] BFCed
+0 !HISTORY 2003-12-19 [PTadmin] Official Update 2003-03
+0 !HISTORY 2007-06-29 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+
+
+1 16 40 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+1 16 20 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+1 16 0 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+1 16 -20 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+1 16 -40 4 0 1 0 0 0 -1 0 0 0 1 stud4.dat
+0 BFC INVERTNEXT
+1 16 0 8 0 56 0 0 0 -4 0 0 0 16 box5.dat
+4 16 -60 8 20 -56 8 16 56 8 16 60 8 20
+4 16 60 8 -20 56 8 -16 -56 8 -16 -60 8 -20
+4 16 60 8 20 56 8 16 56 8 -16 60 8 -20
+4 16 -60 8 -20 -56 8 -16 -56 8 16 -60 8 20
+1 16 0 8 0 60 0 0 0 -8 0 0 0 20 box5.dat
+1 16 50 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 30 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -30 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -50 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 50 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 30 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -30 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -50 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+0

--- a/public/ldraw/parts/s/3002s01.dat
+++ b/public/ldraw/parts/s/3002s01.dat
@@ -1,0 +1,46 @@
+0 ~Brick  2 x  3 without Front Face
+0 Name: s\3002s01.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Subpart UPDATE 2003-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2002-05-07 {unknown} BFC Certification
+0 !HISTORY 2003-07-03 [Steffen] Subfiled for patterns
+0 !HISTORY 2003-12-19 [PTadmin] Official Update 2003-03
+0 !HISTORY 2007-08-29 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+
+
+1 16 10 4 0 1 0 0 0 -5 0 0 0 1 stud4.dat
+1 16 -10 4 0 1 0 0 0 -5 0 0 0 1 stud4.dat
+0 BFC INVERTNEXT
+1 16 0 24 0 26 0 0 0 -20 0 0 0 16 box5.dat
+4 16 30 24 20 26 24 16 -26 24 16 -30 24 20
+4 16 -30 24 20 -26 24 16 -26 24 -16 -30 24 -20
+4 16 -30 24 -20 -26 24 -16 26 24 -16 30 24 -20
+4 16 30 24 -20 26 24 -16 26 24 16 30 24 20
+2 24 30 0 20 -30 0 20
+2 24 -30 0 20 -30 0 -20
+2 24 -30 0 -20 30 0 -20
+2 24 30 0 -20 30 0 20
+2 24 30 24 20 -30 24 20
+2 24 -30 24 20 -30 24 -20
+2 24 -30 24 -20 30 24 -20
+2 24 30 24 -20 30 24 20
+2 24 30 24 20 30 0 20
+2 24 -30 24 20 -30 0 20
+2 24 30 24 -20 30 0 -20
+2 24 -30 24 -20 -30 0 -20
+4 16 -30 0 -20 30 0 -20 30 0 20 -30 0 20
+4 16 30 0 20 30 24 20 -30 24 20 -30 0 20
+4 16 -30 0 20 -30 24 20 -30 24 -20 -30 0 -20
+4 16 30 0 -20 30 24 -20 30 24 20 30 0 20
+1 16 20 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 0 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -20 0 10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 20 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 0 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -20 0 -10 1 0 0 0 1 0 0 0 1 stud.dat
+0

--- a/public/ldraw/parts/s/3003s01.dat
+++ b/public/ldraw/parts/s/3003s01.dat
@@ -1,0 +1,15 @@
+0 ~Brick  2 x  2 without Front Face
+0 Name: s\3003s01.dat
+0 Author: Steffen [Steffen]
+0 !LDRAW_ORG Subpart UPDATE 2013-02
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2009-05-02 [PTadmin] Official Update 2009-01
+0 !HISTORY 2013-04-02 [Steffen] used s\3003s02.dat
+0 !HISTORY 2013-12-23 [PTadmin] Official Update 2013-02
+
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 s\3003s02.dat
+4 16 20 24 20 -20 24 20 -20 0 20 20 0 20

--- a/public/ldraw/parts/s/3003s02.dat
+++ b/public/ldraw/parts/s/3003s02.dat
@@ -1,0 +1,22 @@
+0 ~Brick  2 x  2 without Front and Back Faces
+0 Name: s\3003s02.dat
+0 Author: Owen Burgoyne [C3POwen]
+0 !LDRAW_ORG Subpart UPDATE 2013-02
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2013-12-23 [PTadmin] Official Update 2013-02
+
+
+1 16 0 4 0 1 0 0 0 -5 0 0 0 1 stud4.dat
+0 BFC INVERTNEXT
+1 16 0 24 0 16 0 0 0 -20 0 0 0 16 box5.dat
+4 16 20 24 20 16 24 16 -16 24 16 -20 24 20
+4 16 -20 24 20 -16 24 16 -16 24 -16 -20 24 -20
+4 16 -20 24 -20 -16 24 -16 16 24 -16 20 24 -20
+4 16 20 24 -20 16 24 -16 16 24 16 20 24 20
+2 24 20 24 20 -20 24 20
+2 24 20 24 -20 -20 24 -20
+1 16 0 24 0 0 0 20 0 -24 0 -20 0 0 box3u2p.dat
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 stug-2x2.dat

--- a/public/ldraw/parts/s/3004s01.dat
+++ b/public/ldraw/parts/s/3004s01.dat
@@ -1,0 +1,25 @@
+0 ~Brick  1 x  2 without Front Face
+0 Name: s\3004s01.dat
+0 Author: James Jessiman
+0 !LDRAW_ORG Subpart UPDATE 2003-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2003-09-07 [jriley] Subfiling, BFC
+0 !HISTORY 2003-12-19 [PTadmin] Official Update 2003-03
+0 !HISTORY 2007-08-29 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+
+
+1 16 0 4 0 1 0 0 0 -5 0 0 0 1 stud3.dat
+0 BFC INVERTNEXT
+1 16 0 24 0 16 0 0 0 -20 0 0 0 6 box5.dat
+4 16 20 24 10 16 24 6 -16 24 6 -20 24 10
+4 16 -20 24 10 -16 24 6 -16 24 -6 -20 24 -10
+4 16 -20 24 -10 -16 24 -6 16 24 -6 20 24 -10
+4 16 20 24 -10 16 24 -6 16 24 6 20 24 10
+1 16 0 24 0 20 0 0 0 -24 0 0 0 10 box4t.dat
+1 16 10 0 0 1 0 0 0 1 0 0 0 1 stud.dat
+1 16 -10 0 0 1 0 0 0 1 0 0 0 1 stud.dat
+0

--- a/public/ldraw/parts/s/3005s01.dat
+++ b/public/ldraw/parts/s/3005s01.dat
@@ -1,0 +1,24 @@
+0 ~Brick  1 x  1 without Front Face
+0 Name: s\3005s01.dat
+0 Author: Willy Tschager [Holly-Wood]
+0 !LDRAW_ORG Subpart UPDATE 2024-04
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2003-09-07 [jriley] BFCed & Subfiled
+0 !HISTORY 2004-03-02 [PTadmin] Official Update 2004-01
+0 !HISTORY 2007-08-29 [PTadmin] Header formatted for Contributor Agreement
+0 !HISTORY 2008-07-01 [PTadmin] Official Update 2008-01
+0 !HISTORY 2024-03-15 [Holly-Wood] Complete re-write, original by jriley
+0 !HISTORY 2024-05-28 [OrionP] Official Update 2024-04
+
+1 16 0 0 0 0 0 1 0 1 0 -1 0 0 stud.dat
+1 16 0 24 0 -10 0 0 0 -24 0 0 0 10 box4t.dat
+0 BFC INVERTNEXT
+1 16 0 24 0 -6 0 0 0 -20 0 0 0 6 box5.dat
+
+4 16 -6 24 -6 6 24 -6 10 24 -10 -10 24 -10
+4 16 10 24 -10 6 24 -6 6 24 6 10 24 10
+4 16 6 24 6 -6 24 6 -10 24 10 10 24 10
+4 16 -10 24 10 -6 24 6 -6 24 -6 -10 24 -10

--- a/public/ldraw/parts/s/3023bs01.dat
+++ b/public/ldraw/parts/s/3023bs01.dat
@@ -1,0 +1,24 @@
+0 ~Plate  1 x  2 without Front Face
+0 Name: s\3023bs01.dat
+0 Author: Massimo Maso [Sirio]
+0 !LDRAW_ORG Subpart UPDATE 2023-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2022-01-14 [PTadmin] Official Update 2022-01
+0 !HISTORY 2023-05-27 [OrionP] Moved from s\3023s01.dat
+0 !HISTORY 2023-06-24 [OrionP] Official Update 2023-03
+
+
+0 // Primitves
+1 16 0 4 0 1 0 0 0 -1 0 0 0 1 stud3.dat
+0 BFC INVERTNEXT
+1 16 0 8 0 16 0 0 0 -4 0 0 0 6 box5.dat
+1 16 0 8 0 20 0 0 0 -8 0 0 0 10 box4t.dat
+1 16 0 0 0 1 0 0 0 1 0 0 0 1 stug-1x2.dat
+0 // Faces
+4 16 20 8 10 16 8 6 -16 8 6 -20 8 10
+4 16 -20 8 10 -16 8 6 -16 8 -6 -20 8 -10
+4 16 -20 8 -10 -16 8 -6 16 8 -6 20 8 -10
+4 16 20 8 -10 16 8 -6 16 8 6 20 8 10

--- a/public/ldraw/parts/s/3024s01.dat
+++ b/public/ldraw/parts/s/3024s01.dat
@@ -1,0 +1,19 @@
+0 ~Plate  1 x  1 without Front Face
+0 Name: s\3024s01.dat
+0 Author: Tore Eriksson [Tore_Eriksson]
+0 !LDRAW_ORG Subpart UPDATE 2012-03
+0 !LICENSE Licensed under CC BY 4.0 : see CAreadme.txt
+
+0 BFC CERTIFY CCW
+
+0 !HISTORY 2012-12-28 [PTadmin] Official Update 2012-03
+
+
+0 BFC INVERTNEXT
+1 16 0 8 0 0 0 6 0 -4 0 -6 0 0 box5.dat
+4 16 10 8 -10 6 8 -6 6 8 6 10 8 10
+4 16 10 8 10 6 8 6 -6 8 6 -10 8 10
+4 16 -10 8 10 -6 8 6 -6 8 -6 -10 8 -10
+4 16 -10 8 -10 -6 8 -6 6 8 -6 10 8 -10
+1 16 0 8 0 10 0 0 0 -8 0 0 0 10 box4t.dat
+1 16 0 0 0 0 0 1 0 1 0 -1 0 0 stud.dat

--- a/src/components/ui/bottom-bricks-dock.tsx
+++ b/src/components/ui/bottom-bricks-dock.tsx
@@ -11,23 +11,27 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import Image from "next/image";
 import { useState, useMemo } from "react";
+import { BRICK_CATALOG } from "config/brick-config";
 
 type BricksCategory = "all" | "full" | "plate";
 
 const bricksBoxs = [
-  { name: "1x1", path: "/bricks-image/1x1.png", type: "full" },
-  { name: "1x2", path: "/bricks-image/1x2.png", type: "full" },
-  { name: "2x2", path: "/bricks-image/2x2.png", type: "full" },
-  { name: "2x3", path: "/bricks-image/2x3.png", type: "full" },
-  { name: "2x4", path: "/bricks-image/2x4.png", type: "full" },
-  { name: "2x6", path: "/bricks-image/2x6.png", type: "full" },
-  { name: "half1x1", path: "/bricks-image/half1x1.png", type: "plate" },
-  { name: "half1x2", path: "/bricks-image/half1x2.png", type: "plate" },
-  { name: "half2x2", path: "/bricks-image/half2x2.png", type: "plate" },
-  { name: "half2x3", path: "/bricks-image/half2x3.png", type: "plate" },
-  { name: "half2x4", path: "/bricks-image/half2x4.png", type: "plate" },
-  { name: "half2x6", path: "/bricks-image/half2x6.png", type: "plate" },
+  { name: "1x1 Brick", path: "/bricks-image/1x1.png", type: "full" },
+  { name: "1x2 Brick", path: "/bricks-image/1x2.png", type: "full" },
+  { name: "2x2 Brick", path: "/bricks-image/2x2.png", type: "full" },
+  { name: "2x3 Brick", path: "/bricks-image/2x3.png", type: "full" },
+  { name: "2x4 Brick", path: "/bricks-image/2x4.png", type: "full" },
+  { name: "2x6 Brick", path: "/bricks-image/2x6.png", type: "full" },
+
+  { name: "1x1 Plate", path: "/bricks-image/half1x1.png", type: "plate" },
+  { name: "1x2 Plate", path: "/bricks-image/half1x2.png", type: "plate" },
+  { name: "2x2 Plate", path: "/bricks-image/half2x2.png", type: "plate" },
+  { name: "2x3 Plate", path: "/bricks-image/half2x3.png", type: "plate" },
+  { name: "2x4 Plate", path: "/bricks-image/half2x4.png", type: "plate" },
+  { name: "2x6 Plate", path: "/bricks-image/half2x6.png", type: "plate" },
 ];
+
+const CATALOG_BY_NAME = new Map(BRICK_CATALOG.map((item) => [item.name, item]));
 
 const BottomBricksDock = () => {
   const [bricksCategory, setBricksCategory] = useState<BricksCategory>("all");
@@ -85,9 +89,13 @@ const BottomBricksDock = () => {
       <ScrollArea className="h-20">
         <div className="flex h-full items-center justify-center gap-2 px-3">
           {filteredBricksBoxs.map((box) => (
-            <div
+            <button
               key={box.name}
               className="relative flex h-16 w-16 shrink-0 items-center justify-center rounded-md border bg-muted/60 mt-1"
+              onClick={() => {
+                const item = CATALOG_BY_NAME.get(box.name);
+                window.dispatchEvent(new CustomEvent("spawn-brick", { detail: item }));
+              }}
             >
               <Image
                 src={box.path}
@@ -97,7 +105,7 @@ const BottomBricksDock = () => {
                 className="object-contain"
               />
               <div className="absolute bottom-0 left-0 right-0 h-3 bg-background/70" />
-            </div>
+            </button>
           ))}
           <div className="w-3 shrink-0 md:w-4" />
         </div>

--- a/src/components/workshop/layers-panel.tsx
+++ b/src/components/workshop/layers-panel.tsx
@@ -1,44 +1,46 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 type Layer = {
-  id: string;
+  uuid: string;
   name: string;
 };
 
-// 더미 데이터: 추후 브릭 렌더링 데이터 연결 예정
-const dummyLayers: Layer[] = [
-  { id: "l-1", name: "2x4" },
-  { id: "l-2", name: "1x2" },
-  { id: "l-3", name: "half2x4" },
-  { id: "l-4", name: "half2x3" },
-  { id: "l-5", name: "half2x3" },
-  { id: "l-6", name: "4x4" },
-  { id: "l-7", name: "1x3" },
-  { id: "l-8", name: "half2x3" },
-  { id: "l-9", name: "2x6" },
-  { id: "l-10", name: "half2x3" },
-];
-
 const LayersPanel = () => {
-  const [selectedId, setSelectedId] = useState<string | null>(dummyLayers[0]?.id ?? null);
+  const [layers, setLayers] = useState<Layer[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  // TODO: 추후 브릭 렌더링 로직과 연결 시,
-  // - 여기서 selectedId를 전역 상태(zustand)or props로 onSelect를 받아서 캔버스 쪽과 동기화 예정
+  const selectLayer = useCallback((uuid: string) => {
+    setSelectedId(uuid);
+    window.dispatchEvent(new CustomEvent("select-layer", { detail: { uuid } }));
+  }, []);
+
+  useEffect(() => {
+    const addedLayer = (event: Event) => {
+      const { uuid, name } = (event as CustomEvent<Layer>).detail;
+
+      setLayers((prev) => [...prev, { uuid, name }]);
+    };
+
+    window.addEventListener("layer-added", addedLayer);
+    return () => {
+      window.removeEventListener("layer-added", addedLayer);
+    };
+  }, []);
 
   return (
     <div className="flex w-full flex-col gap-2">
       <div className="text-sm font-medium">Layers</div>
       <ScrollArea className="h-[320px] rounded-md border">
         <div className="flex flex-col">
-          {dummyLayers.map((layer) => {
-            const isSelected = layer.id === selectedId;
+          {layers.map((layer) => {
+            const isSelected = layer.uuid === selectedId;
             return (
               <button
-                key={layer.id}
-                onClick={() => setSelectedId(layer.id)}
+                key={layer.uuid}
+                onClick={() => selectLayer(layer.uuid)}
                 className={`flex items-center gap-2 px-2 py-2 text-left border-b last:border-b-0 ${
                   isSelected ? "bg-accent text-accent-foreground" : "hover:bg-muted/60"
                 }`}
@@ -47,7 +49,7 @@ const LayersPanel = () => {
               </button>
             );
           })}
-          {dummyLayers.length === 0 && (
+          {layers.length === 0 && (
             <div className="flex h-20 items-center justify-center text-xs text-muted-foreground">
               No layers
             </div>

--- a/src/components/workshop/ldraw-model.tsx
+++ b/src/components/workshop/ldraw-model.tsx
@@ -5,6 +5,9 @@ import { LDrawLoader } from "three/examples/jsm/loaders/LDrawLoader.js";
 import { useThree } from "@react-three/fiber";
 import { LDrawConditionalLineMaterial } from "three/examples/jsm/materials/LDrawConditionalLineMaterial.js";
 import * as THREE from "three";
+import { LDRAW_PATH } from "config/brick-config";
+
+type SpawnBrickEvent = CustomEvent<{ path: string }>;
 
 const LDrawModel = () => {
   const { scene } = useThree();
@@ -13,18 +16,25 @@ const LDrawModel = () => {
     const loader = new LDrawLoader();
 
     loader.setConditionalLineMaterial(LDrawConditionalLineMaterial);
-    loader.setPartsLibraryPath("/ldraw/");
-    loader.load("/ldraw/parts/3001.dat", (group) => {
-      group.scale.set(0.5, 0.5, 0.5);
-      group.position.set(0, 0, 0);
-      group.rotateX(Math.PI);
+    loader.setPartsLibraryPath(LDRAW_PATH);
 
-      const box = new THREE.Box3().setFromObject(group);
-      if (isFinite(box.min.y) && box.min.y !== 0) {
-        group.position.y -= box.min.y;
-      }
-      scene.add(group);
-    });
+    const onSpawn = (event: SpawnBrickEvent) => {
+      const { path } = event.detail;
+
+      loader.load(path, (group) => {
+        group.scale.set(0.5, 0.5, 0.5);
+        group.position.set(0, 0, 0);
+        group.rotateX(Math.PI);
+
+        const box = new THREE.Box3().setFromObject(group);
+        if (isFinite(box.min.y) && box.min.y !== 0) {
+          group.position.y -= box.min.y;
+        }
+        scene.add(group);
+      });
+    };
+    window.addEventListener("spawn-brick", onSpawn as EventListener);
+    return () => window.removeEventListener("spawn-brick", onSpawn as EventListener);
   }, [scene]);
 
   return null;

--- a/src/components/workshop/ldraw-model.tsx
+++ b/src/components/workshop/ldraw-model.tsx
@@ -7,7 +7,7 @@ import { LDrawConditionalLineMaterial } from "three/examples/jsm/materials/LDraw
 import * as THREE from "three";
 import { LDRAW_PATH } from "config/brick-config";
 
-type SpawnBrickEvent = CustomEvent<{ path: string }>;
+type SpawnBrickEvent = { name: string; path: string };
 
 const LDrawModel = () => {
   const { scene } = useThree();
@@ -18,8 +18,8 @@ const LDrawModel = () => {
     loader.setConditionalLineMaterial(LDrawConditionalLineMaterial);
     loader.setPartsLibraryPath(LDRAW_PATH);
 
-    const onSpawn = (event: SpawnBrickEvent) => {
-      const { path } = event.detail;
+    const onSpawn = (event: Event) => {
+      const { path, name } = (event as CustomEvent<SpawnBrickEvent>).detail;
 
       loader.load(path, (group) => {
         group.scale.set(0.5, 0.5, 0.5);
@@ -31,10 +31,16 @@ const LDrawModel = () => {
           group.position.y -= box.min.y;
         }
         scene.add(group);
+
+        window.dispatchEvent(
+          new CustomEvent("layer-added", {
+            detail: { uuid: group.uuid, name },
+          })
+        );
       });
     };
-    window.addEventListener("spawn-brick", onSpawn as EventListener);
-    return () => window.removeEventListener("spawn-brick", onSpawn as EventListener);
+    window.addEventListener("spawn-brick", onSpawn);
+    return () => window.removeEventListener("spawn-brick", onSpawn);
   }, [scene]);
 
   return null;


### PR DESCRIPTION
### 구현 화면

https://github.com/user-attachments/assets/024562d6-09c4-490f-b153-babf0f97d5ee




---


### 상세설명
- LDrawModel 컴포넌트
  - 씬(scene)에 추가된 후 layer-added 이벤트를 발행하여 레이어 UI와 동기화 
  - /ldraw/ 경로 기반으로 파츠 라이브러리 지정 

- LayersPanel 컴포넌트
  - layer-added 이벤트를 수신하여 렌더 완료된 브릭만 레이어 목록에 추가
  - 목록에서 클릭 시 select-layer 이벤트 발행 (선택 상태 전파)
  - 중복 허용, 자동 선택 없음 → 스폰된 순서대로 누적 표시

- 흐름
  - 브릭 선택 → spawn-brick 발행
  - LDrawModel이 브릭 로드 후 layer-added 발생
  - LayersPanel이 수신하여 목록에 반영
	
---

### 참고사항
- 현재는 브릭 로드 시 색상은 기본값(검정)으로 렌더링 → 추후 색상 선택 UI 및 팔레트 연계 예정
- 브릭 삭제 및 레이어 창 내부에서 선택 후 삭제는 다음 pr에서 구현 예정
- 구조는 이벤트 기반으로 작성되어 있어, 필요 시 Zustand 등 전역 상태로 확장 가능

---

